### PR TITLE
Add Docker Compose docs and cleanup compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,33 @@ This project is a Spring Boot application that can be built with Maven or Gradle
 ./gradlew bootBuildImage --imageName=best_insurance/api -x test
 ```
 
+
+## Running with Docker Compose
+
+Build the image first with Maven or Gradle:
+
+```bash
+./mvnw spring-boot:build-image -DskipTests -Dspring-boot.build-image.imageName=best_insurance/api
+# or
+./gradlew bootBuildImage --imageName=best_insurance/api -x test
+```
+
+Start the services:
+
+```bash
+docker-compose -f docker/docker-compose.yml up
+```
+
+Stop the services when done:
+
+```bash
+docker-compose -f docker/docker-compose.yml down
+```
+
+To clean up the image:
+
+```bash
+docker rmi best_insurance/api
+```
+
+You may also run `docker image prune` to remove dangling images.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  app:
+    image: best_insurance/api
+    depends_on:
+      - db
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/best_insurance
+      SPRING_DATASOURCE_USERNAME: bestinsurance
+      SPRING_DATASOURCE_PASSWORD: bestinsurance
+      SPRING_JPA_HIBERNATE_DDL_AUTO: validate
+      BPL_DEBUG_ENABLED: "true"
+      BPL_DEBUG_PORT: 5005
+      BPL_DEBUG_SUSPEND: "false"
+    ports:
+      - "8080:8080"
+      - "5005:5005"
+  db:
+    image: postgres:14.5-alpine
+    environment:
+      POSTGRES_DB: best_insurance
+      POSTGRES_USER: bestinsurance
+      POSTGRES_PASSWORD: bestinsurance
+    ports:
+      - "5432:5432"
+  adminer:
+    image: adminer
+    depends_on:
+      - db
+    ports:
+      - "8081:8080"

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,5 @@
+databaseChangeLog:
+    - changeSet:
+        id:  1
+        author:  bestDev
+        changes:


### PR DESCRIPTION
## Summary
- document building the Docker image and using Docker Compose in `README.md`
- remove deprecated `version` field from `docker-compose.yml`

## Testing
- `./gradlew test` *(failed: No route to host when downloading Gradle)*