### PR TITLE
Ensure DB readiness for app

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,9 +2,10 @@ services:
   app:
     image: best_insurance/api:latest
     platform: linux/arm64
-    
+
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/best_insurance
       SPRING_DATASOURCE_USERNAME: bestinsurance
@@ -24,6 +25,12 @@ services:
       POSTGRES_PASSWORD: bestinsurance
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
   adminer:
     image: adminer
     depends_on:


### PR DESCRIPTION
## Summary
- wait for postgres to be healthy before starting the app
- add healthcheck for db service

## Testing
- `./gradlew test` *(fails: NoRouteToHostException while downloading Gradle)*